### PR TITLE
Update posts_controller.rb

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,6 +36,7 @@ class PostsController < ApplicationController
   private
   def post_params
     params.require(:post).permit(:title, :content,).merge(user_id: current_user.id)
+    # mergeメソッドを追記
   end
 
 


### PR DESCRIPTION
# what 
　mergeメソッドを追記

#why
　devise導入により、新規投稿をした際にユーザidがDBに保存されていなかった為
　投稿の反映が失敗していたものを修正